### PR TITLE
Utilize existing pixi run commands; add `npm i` to install deps

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -14,7 +14,8 @@ kokoro = ">=0.8"
 soundfile = ">=0.13"
 
 [tasks]
+install = "npm i"
 audio = "python scripts/generate_audio.py"
 record = "npx tsx src/record.ts"
 convert = "bash scripts/convert.sh"
-demo = { cmd = "npx tsx src/record.ts && bash scripts/convert.sh", depends-on = ["audio"] }
+demo = { depends-on = ["install", "audio", "record", "convert"] }


### PR DESCRIPTION
## Reference Issues or PRs

Closes #3.

## What does this implement/fix?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

None.

## Any other comments?

Previously `pixi run demo` didn't install any node packages, meaning the pixi command just failed unless the user did this manually. This PR fixes that.

Additionally, this PR ensures that the actual pixi commands that `pixi run demo` depends on are called, instead of partially duplicating them (?) inside.