### PR TITLE
Fix issues failing to download and extract the nebi binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@types/node": "^22.0.0",
         "playwright": "^1.52.0",
+        "tar": "^7.5.11",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
       }
@@ -428,6 +429,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -435,6 +448,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/esbuild": {
@@ -504,6 +526,27 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
@@ -541,6 +584,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tsx": {
@@ -594,6 +653,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@types/node": "^22.0.0",
     "playwright": "^1.52.0",
+    "tar": "^7.5.11",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"
   }

--- a/src/record.ts
+++ b/src/record.ts
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as net from "net";
 import { chromium } from "playwright";
 import { showAnnotation, hideAnnotation, showFinalOverlay, demoClick, demoType, hideCursor } from "./annotations";
+import * as tar from "tar";
 
 // Load .env file from repo root
 const envPath = path.resolve(__dirname, "..", ".env");
@@ -32,22 +33,53 @@ function getPlatformInfo(): { os: string; arch: string } {
   const platform = process.platform;
   const arch = process.arch;
   const os = platform === "darwin" ? "darwin" : platform === "win32" ? "windows" : "linux";
-  const goArch = arch === "arm64" ? "arm64" : "amd64";
+  const goArch = arch === "arm64" ? "arm64" : "x86_64";
   return { os, arch: goArch };
 }
 
+/**
+ * Downloads the latest nebi binary from GitHub releases.
+ *
+ * Fetches the latest release from the nebi GitHub repository, identifies the
+ * appropriate binary for the current platform and architecture, downloads it,
+ * and saves it to the specified destination with executable permissions.
+ *
+ * @param dest - The absolute path where the binary should be saved
+ * @throws {Error} If the GitHub API request fails
+ * @throws {Error} If no matching binary asset is found for the current platform
+ * @throws {Error} If the binary download fails
+ */
 async function downloadBinary(dest: string): Promise<void> {
   const { os, arch } = getPlatformInfo();
-  const filename = `nebi-${os}-${arch}`;
-  const url = `https://github.com/nebari-dev/nebi/releases/latest/download/${filename}`;
-  console.log(`Downloading nebi binary from ${url}...`);
 
-  const res = await fetch(url, { redirect: "follow" });
+  const apiUrl = "https://api.github.com/repos/nebari-dev/nebi/releases/latest";
+  const releaseRes = await fetch(apiUrl, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!releaseRes.ok) throw new Error(`Failed to fetch release info: ${releaseRes.status} ${releaseRes.statusText}`);
+
+  const release = await releaseRes.json() as { assets: Array<{ name: string; browser_download_url: string }> };
+  const asset = release.assets.find((a) => !a.name.includes('desktop') && a.name.includes(os) && a.name.includes(arch));
+  if (!asset) throw new Error(`No nebi release found for ${os}/${arch}. Available: ${release.assets.map((a) => a.name).join(", ")}`);
+
+  console.log(`Downloading nebi asset from ${asset.browser_download_url}...`);
+  const res = await fetch(asset.browser_download_url, { redirect: "follow" });
   if (!res.ok) throw new Error(`Failed to download binary: ${res.status} ${res.statusText}`);
 
   const buffer = Buffer.from(await res.arrayBuffer());
+  const fname = asset.browser_download_url.substring(asset.browser_download_url.lastIndexOf('/')+1)
+  const binDir = path.dirname(dest)
+  const tarFile = path.join(binDir, fname)
+
   fs.mkdirSync(path.dirname(dest), { recursive: true });
-  fs.writeFileSync(dest, buffer);
+  fs.writeFileSync(tarFile, buffer);
+
+  console.log(`Extracting ${tarFile}...`)
+  await tar.x({f: tarFile, cwd: binDir})
+  if (!fs.existsSync(path.join(path.dirname(dest), 'nebi'))) {
+    throw new Error(`${fname} has no binary name 'nebi'. Aborting.`)
+  }
+
   fs.chmodSync(dest, 0o755);
   console.log(`Binary downloaded to ${dest}`);
 }


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #4.

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

Previously `pixi run demo` would fail to download the correct nebi release artifact. On linux, there is no `amd64` artifact, and anyway all the artifacts are compressed gzipped archives. I'm not sure how this tool was working at all in the past.

These changes download the correct `.tar.gz` for the current OS/arch, then use `node-tar` to gunzip and untar the archive to the correct location.